### PR TITLE
Fix index error when building 'imports' array

### DIFF
--- a/src/macholibre/parser.py
+++ b/src/macholibre/parser.py
@@ -224,7 +224,7 @@ class Parser(object):
                     if i.dylib == 0:
                         dylib = 'SELF_LIBRARY'
                     elif i.dylib <= len(macho.dylibs):
-                        dylib = macho.dylibs[i.dylib - 1]
+                        dylib = macho.dylibs[i.dylib]
                     elif i.dylib == 254:
                         dylib = 'DYNAMIC_LOOKUP'
                     elif i.dylib == 255:


### PR DESCRIPTION
The list macho.dylibs appears to include the current target file at index 0. Other dylibs therefore appear at index 1 and above. There is no need to subtract 1 from the dylib index; doing so leads to symbols being listed associated with the wrong dylibs.